### PR TITLE
run_constrain antlr-python-runtime, remove setuptools runtime dep

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 About sympy
 ===========
 
-Home: http://sympy.org
+Home: https://sympy.org
 
 Package license: BSD-3-Clause
 

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -26,7 +26,7 @@ requirements:
     - python
     - gmpy2 >=2.0.8   # [not win]
   run_constrained:
-    - antlr-python-runtime >=4.7,<4.8
+    - antlr-python-runtime >=4.7,<4.8  # [not aarch64 and not ppc64le]
 
 test:
   requires:

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -9,7 +9,7 @@ source:
   sha256: d77901d748287d15281f5ffe5b0fef62dd38f357c2b827c44ff07f35695f4e7e
 
 build:
-  number: 0
+  number: 1
   script: "{{ PYTHON }} -m pip install . --no-deps --ignore-installed --no-cache-dir -vvv"
   entry_points:
     - isympy = isympy:main
@@ -22,19 +22,22 @@ requirements:
     - python
   run:
     - fastcache
-    - setuptools
     - mpmath >=0.19
     - python
     - gmpy2 >=2.0.8   # [not win]
+  run_constrained:
+    - antlr-python-runtime >=4.7,<4.8
 
 test:
+  requires:
+    - antlr-python-runtime
   commands:
     - isympy --help
   imports:
     - sympy
 
 about:
-  home: http://sympy.org
+  home: https://sympy.org
   license: BSD-3-Clause
   license_family: BSD
   license_file: LICENSE
@@ -43,8 +46,9 @@ about:
     SymPy is a Python library for symbolic mathematics. It aims to become a
     full-featured computer algebra system (CAS) while keeping the code as
     simple as possible in order to be comprehensible and easily extensible.
-  doc_url: http://docs.sympy.org/latest/index.html
+  doc_url: https://docs.sympy.org/latest/index.html
   dev_url: https://github.com/sympy/sympy
+  doc_source_url: https://github.com/sympy/sympy/tree/master/doc
 
 extra:
   recipe-maintainers:

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -26,7 +26,7 @@ requirements:
     - python
     - gmpy2 >=2.0.8   # [not win]
   run_constrained:
-    - antlr-python-runtime >=4.7,<4.8  # [not aarch64 and not ppc64le]
+    - antlr-python-runtime >=4.7,<4.8
 
 test:
   requires:

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -29,8 +29,6 @@ requirements:
     - antlr-python-runtime >=4.7,<4.8
 
 test:
-  requires:
-    - antlr-python-runtime
   commands:
     - isympy --help
   imports:


### PR DESCRIPTION
Checklist
* [x] Used a [fork of the feedstock to propose changes](https://conda-forge.org/docs/maintainer/updating_pkgs.html#forking-and-pull-requests)
* [x] Bumped the build number (if the version is unchanged)
* [ ] Reset the build number to `0` (if the version changed)
* [x] [Re-rendered]( https://conda-forge.org/docs/maintainer/updating_pkgs.html#rerendering-feedstocks ) with the latest `conda-smithy` (Use the phrase <code>@<space/>conda-forge-admin, please rerender</code> in a comment in this PR for automated rerendering)
* [x] Ensured the license file is being packaged.

- fixes #20 by removing `setuptools` as a runtime dep
- as per https://github.com/sympy/sympy/issues/17629#issuecomment-533688907, this adds a `run_constrained` for antlr-python-runtime
  - 4.8 is [ready to release](https://github.com/conda-forge/antlr-python-runtime-feedstock/pull/4), but want to make sure this is in order