### PR TITLE
Fix antlr-python-runtime constraint to 4.10

### DIFF
--- a/.azure-pipelines/azure-pipelines-linux.yml
+++ b/.azure-pipelines/azure-pipelines-linux.yml
@@ -8,28 +8,64 @@ jobs:
     vmImage: ubuntu-latest
   strategy:
     matrix:
-      linux_64_python_implcpython:
-        CONFIG: linux_64_python_implcpython
+      linux_64_python3.10.____cpythonpython_implcpython:
+        CONFIG: linux_64_python3.10.____cpythonpython_implcpython
         UPLOAD_PACKAGES: 'True'
         DOCKER_IMAGE: quay.io/condaforge/linux-anvil-cos7-x86_64
-      linux_64_python_implpypy:
-        CONFIG: linux_64_python_implpypy
+      linux_64_python3.8.____73_pypypython_implpypy:
+        CONFIG: linux_64_python3.8.____73_pypypython_implpypy
         UPLOAD_PACKAGES: 'True'
         DOCKER_IMAGE: quay.io/condaforge/linux-anvil-cos7-x86_64
-      linux_aarch64_python_implcpython:
-        CONFIG: linux_aarch64_python_implcpython
+      linux_64_python3.8.____cpythonpython_implcpython:
+        CONFIG: linux_64_python3.8.____cpythonpython_implcpython
         UPLOAD_PACKAGES: 'True'
         DOCKER_IMAGE: quay.io/condaforge/linux-anvil-cos7-x86_64
-      linux_aarch64_python_implpypy:
-        CONFIG: linux_aarch64_python_implpypy
+      linux_64_python3.9.____73_pypypython_implpypy:
+        CONFIG: linux_64_python3.9.____73_pypypython_implpypy
         UPLOAD_PACKAGES: 'True'
         DOCKER_IMAGE: quay.io/condaforge/linux-anvil-cos7-x86_64
-      linux_ppc64le_python_implcpython:
-        CONFIG: linux_ppc64le_python_implcpython
+      linux_64_python3.9.____cpythonpython_implcpython:
+        CONFIG: linux_64_python3.9.____cpythonpython_implcpython
         UPLOAD_PACKAGES: 'True'
         DOCKER_IMAGE: quay.io/condaforge/linux-anvil-cos7-x86_64
-      linux_ppc64le_python_implpypy:
-        CONFIG: linux_ppc64le_python_implpypy
+      linux_aarch64_python3.10.____cpythonpython_implcpython:
+        CONFIG: linux_aarch64_python3.10.____cpythonpython_implcpython
+        UPLOAD_PACKAGES: 'True'
+        DOCKER_IMAGE: quay.io/condaforge/linux-anvil-cos7-x86_64
+      linux_aarch64_python3.8.____73_pypypython_implpypy:
+        CONFIG: linux_aarch64_python3.8.____73_pypypython_implpypy
+        UPLOAD_PACKAGES: 'True'
+        DOCKER_IMAGE: quay.io/condaforge/linux-anvil-cos7-x86_64
+      linux_aarch64_python3.8.____cpythonpython_implcpython:
+        CONFIG: linux_aarch64_python3.8.____cpythonpython_implcpython
+        UPLOAD_PACKAGES: 'True'
+        DOCKER_IMAGE: quay.io/condaforge/linux-anvil-cos7-x86_64
+      linux_aarch64_python3.9.____73_pypypython_implpypy:
+        CONFIG: linux_aarch64_python3.9.____73_pypypython_implpypy
+        UPLOAD_PACKAGES: 'True'
+        DOCKER_IMAGE: quay.io/condaforge/linux-anvil-cos7-x86_64
+      linux_aarch64_python3.9.____cpythonpython_implcpython:
+        CONFIG: linux_aarch64_python3.9.____cpythonpython_implcpython
+        UPLOAD_PACKAGES: 'True'
+        DOCKER_IMAGE: quay.io/condaforge/linux-anvil-cos7-x86_64
+      linux_ppc64le_python3.10.____cpythonpython_implcpython:
+        CONFIG: linux_ppc64le_python3.10.____cpythonpython_implcpython
+        UPLOAD_PACKAGES: 'True'
+        DOCKER_IMAGE: quay.io/condaforge/linux-anvil-cos7-x86_64
+      linux_ppc64le_python3.8.____73_pypypython_implpypy:
+        CONFIG: linux_ppc64le_python3.8.____73_pypypython_implpypy
+        UPLOAD_PACKAGES: 'True'
+        DOCKER_IMAGE: quay.io/condaforge/linux-anvil-cos7-x86_64
+      linux_ppc64le_python3.8.____cpythonpython_implcpython:
+        CONFIG: linux_ppc64le_python3.8.____cpythonpython_implcpython
+        UPLOAD_PACKAGES: 'True'
+        DOCKER_IMAGE: quay.io/condaforge/linux-anvil-cos7-x86_64
+      linux_ppc64le_python3.9.____73_pypypython_implpypy:
+        CONFIG: linux_ppc64le_python3.9.____73_pypypython_implpypy
+        UPLOAD_PACKAGES: 'True'
+        DOCKER_IMAGE: quay.io/condaforge/linux-anvil-cos7-x86_64
+      linux_ppc64le_python3.9.____cpythonpython_implcpython:
+        CONFIG: linux_ppc64le_python3.9.____cpythonpython_implcpython
         UPLOAD_PACKAGES: 'True'
         DOCKER_IMAGE: quay.io/condaforge/linux-anvil-cos7-x86_64
   timeoutInMinutes: 360

--- a/.azure-pipelines/azure-pipelines-osx.yml
+++ b/.azure-pipelines/azure-pipelines-osx.yml
@@ -8,14 +8,29 @@ jobs:
     vmImage: macOS-11
   strategy:
     matrix:
-      osx_64_python_implcpython:
-        CONFIG: osx_64_python_implcpython
+      osx_64_python3.10.____cpythonpython_implcpython:
+        CONFIG: osx_64_python3.10.____cpythonpython_implcpython
         UPLOAD_PACKAGES: 'True'
-      osx_64_python_implpypy:
-        CONFIG: osx_64_python_implpypy
+      osx_64_python3.8.____73_pypypython_implpypy:
+        CONFIG: osx_64_python3.8.____73_pypypython_implpypy
         UPLOAD_PACKAGES: 'True'
-      osx_arm64_:
-        CONFIG: osx_arm64_
+      osx_64_python3.8.____cpythonpython_implcpython:
+        CONFIG: osx_64_python3.8.____cpythonpython_implcpython
+        UPLOAD_PACKAGES: 'True'
+      osx_64_python3.9.____73_pypypython_implpypy:
+        CONFIG: osx_64_python3.9.____73_pypypython_implpypy
+        UPLOAD_PACKAGES: 'True'
+      osx_64_python3.9.____cpythonpython_implcpython:
+        CONFIG: osx_64_python3.9.____cpythonpython_implcpython
+        UPLOAD_PACKAGES: 'True'
+      osx_arm64_python3.10.____cpython:
+        CONFIG: osx_arm64_python3.10.____cpython
+        UPLOAD_PACKAGES: 'True'
+      osx_arm64_python3.8.____cpython:
+        CONFIG: osx_arm64_python3.8.____cpython
+        UPLOAD_PACKAGES: 'True'
+      osx_arm64_python3.9.____cpython:
+        CONFIG: osx_arm64_python3.9.____cpython
         UPLOAD_PACKAGES: 'True'
   timeoutInMinutes: 360
 

--- a/.azure-pipelines/azure-pipelines-win.yml
+++ b/.azure-pipelines/azure-pipelines-win.yml
@@ -8,11 +8,20 @@ jobs:
     vmImage: windows-2019
   strategy:
     matrix:
-      win_64_python_implcpython:
-        CONFIG: win_64_python_implcpython
+      win_64_python3.10.____cpythonpython_implcpython:
+        CONFIG: win_64_python3.10.____cpythonpython_implcpython
         UPLOAD_PACKAGES: 'True'
-      win_64_python_implpypy:
-        CONFIG: win_64_python_implpypy
+      win_64_python3.8.____73_pypypython_implpypy:
+        CONFIG: win_64_python3.8.____73_pypypython_implpypy
+        UPLOAD_PACKAGES: 'True'
+      win_64_python3.8.____cpythonpython_implcpython:
+        CONFIG: win_64_python3.8.____cpythonpython_implcpython
+        UPLOAD_PACKAGES: 'True'
+      win_64_python3.9.____73_pypypython_implpypy:
+        CONFIG: win_64_python3.9.____73_pypypython_implpypy
+        UPLOAD_PACKAGES: 'True'
+      win_64_python3.9.____cpythonpython_implcpython:
+        CONFIG: win_64_python3.9.____cpythonpython_implcpython
         UPLOAD_PACKAGES: 'True'
   timeoutInMinutes: 360
   variables:

--- a/.ci_support/linux_64_python3.10.____cpythonpython_implcpython.yaml
+++ b/.ci_support/linux_64_python3.10.____cpythonpython_implcpython.yaml
@@ -1,0 +1,21 @@
+cdt_name:
+- cos6
+channel_sources:
+- conda-forge
+channel_targets:
+- conda-forge main
+docker_image:
+- quay.io/condaforge/linux-anvil-cos7-x86_64
+pin_run_as_build:
+  python:
+    min_pin: x.x
+    max_pin: x.x
+python:
+- 3.10.* *_cpython
+python_impl:
+- cpython
+target_platform:
+- linux-64
+zip_keys:
+- - python
+  - python_impl

--- a/.ci_support/linux_64_python3.8.____73_pypypython_implpypy.yaml
+++ b/.ci_support/linux_64_python3.8.____73_pypypython_implpypy.yaml
@@ -1,0 +1,21 @@
+cdt_name:
+- cos6
+channel_sources:
+- conda-forge
+channel_targets:
+- conda-forge main
+docker_image:
+- quay.io/condaforge/linux-anvil-cos7-x86_64
+pin_run_as_build:
+  python:
+    min_pin: x.x
+    max_pin: x.x
+python:
+- 3.8.* *_73_pypy
+python_impl:
+- pypy
+target_platform:
+- linux-64
+zip_keys:
+- - python
+  - python_impl

--- a/.ci_support/linux_64_python3.8.____cpythonpython_implcpython.yaml
+++ b/.ci_support/linux_64_python3.8.____cpythonpython_implcpython.yaml
@@ -1,0 +1,21 @@
+cdt_name:
+- cos6
+channel_sources:
+- conda-forge
+channel_targets:
+- conda-forge main
+docker_image:
+- quay.io/condaforge/linux-anvil-cos7-x86_64
+pin_run_as_build:
+  python:
+    min_pin: x.x
+    max_pin: x.x
+python:
+- 3.8.* *_cpython
+python_impl:
+- cpython
+target_platform:
+- linux-64
+zip_keys:
+- - python
+  - python_impl

--- a/.ci_support/linux_64_python3.9.____73_pypypython_implpypy.yaml
+++ b/.ci_support/linux_64_python3.9.____73_pypypython_implpypy.yaml
@@ -1,12 +1,21 @@
 cdt_name:
-- cos7
+- cos6
 channel_sources:
 - conda-forge
 channel_targets:
 - conda-forge main
 docker_image:
 - quay.io/condaforge/linux-anvil-cos7-x86_64
+pin_run_as_build:
+  python:
+    min_pin: x.x
+    max_pin: x.x
+python:
+- 3.9.* *_73_pypy
 python_impl:
 - pypy
 target_platform:
-- linux-ppc64le
+- linux-64
+zip_keys:
+- - python
+  - python_impl

--- a/.ci_support/linux_64_python3.9.____cpythonpython_implcpython.yaml
+++ b/.ci_support/linux_64_python3.9.____cpythonpython_implcpython.yaml
@@ -6,7 +6,16 @@ channel_targets:
 - conda-forge main
 docker_image:
 - quay.io/condaforge/linux-anvil-cos7-x86_64
+pin_run_as_build:
+  python:
+    min_pin: x.x
+    max_pin: x.x
+python:
+- 3.9.* *_cpython
 python_impl:
 - cpython
 target_platform:
 - linux-64
+zip_keys:
+- - python
+  - python_impl

--- a/.ci_support/linux_aarch64_python3.10.____cpythonpython_implcpython.yaml
+++ b/.ci_support/linux_aarch64_python3.10.____cpythonpython_implcpython.yaml
@@ -10,7 +10,16 @@ channel_targets:
 - conda-forge main
 docker_image:
 - quay.io/condaforge/linux-anvil-cos7-x86_64
+pin_run_as_build:
+  python:
+    min_pin: x.x
+    max_pin: x.x
+python:
+- 3.10.* *_cpython
 python_impl:
 - cpython
 target_platform:
 - linux-aarch64
+zip_keys:
+- - python
+  - python_impl

--- a/.ci_support/linux_aarch64_python3.8.____73_pypypython_implpypy.yaml
+++ b/.ci_support/linux_aarch64_python3.8.____73_pypypython_implpypy.yaml
@@ -1,0 +1,25 @@
+BUILD:
+- aarch64-conda_cos7-linux-gnu
+cdt_arch:
+- aarch64
+cdt_name:
+- cos7
+channel_sources:
+- conda-forge
+channel_targets:
+- conda-forge main
+docker_image:
+- quay.io/condaforge/linux-anvil-cos7-x86_64
+pin_run_as_build:
+  python:
+    min_pin: x.x
+    max_pin: x.x
+python:
+- 3.8.* *_73_pypy
+python_impl:
+- pypy
+target_platform:
+- linux-aarch64
+zip_keys:
+- - python
+  - python_impl

--- a/.ci_support/linux_aarch64_python3.8.____cpythonpython_implcpython.yaml
+++ b/.ci_support/linux_aarch64_python3.8.____cpythonpython_implcpython.yaml
@@ -1,0 +1,25 @@
+BUILD:
+- aarch64-conda_cos7-linux-gnu
+cdt_arch:
+- aarch64
+cdt_name:
+- cos7
+channel_sources:
+- conda-forge
+channel_targets:
+- conda-forge main
+docker_image:
+- quay.io/condaforge/linux-anvil-cos7-x86_64
+pin_run_as_build:
+  python:
+    min_pin: x.x
+    max_pin: x.x
+python:
+- 3.8.* *_cpython
+python_impl:
+- cpython
+target_platform:
+- linux-aarch64
+zip_keys:
+- - python
+  - python_impl

--- a/.ci_support/linux_aarch64_python3.9.____73_pypypython_implpypy.yaml
+++ b/.ci_support/linux_aarch64_python3.9.____73_pypypython_implpypy.yaml
@@ -1,0 +1,25 @@
+BUILD:
+- aarch64-conda_cos7-linux-gnu
+cdt_arch:
+- aarch64
+cdt_name:
+- cos7
+channel_sources:
+- conda-forge
+channel_targets:
+- conda-forge main
+docker_image:
+- quay.io/condaforge/linux-anvil-cos7-x86_64
+pin_run_as_build:
+  python:
+    min_pin: x.x
+    max_pin: x.x
+python:
+- 3.9.* *_73_pypy
+python_impl:
+- pypy
+target_platform:
+- linux-aarch64
+zip_keys:
+- - python
+  - python_impl

--- a/.ci_support/linux_aarch64_python3.9.____cpythonpython_implcpython.yaml
+++ b/.ci_support/linux_aarch64_python3.9.____cpythonpython_implcpython.yaml
@@ -1,0 +1,25 @@
+BUILD:
+- aarch64-conda_cos7-linux-gnu
+cdt_arch:
+- aarch64
+cdt_name:
+- cos7
+channel_sources:
+- conda-forge
+channel_targets:
+- conda-forge main
+docker_image:
+- quay.io/condaforge/linux-anvil-cos7-x86_64
+pin_run_as_build:
+  python:
+    min_pin: x.x
+    max_pin: x.x
+python:
+- 3.9.* *_cpython
+python_impl:
+- cpython
+target_platform:
+- linux-aarch64
+zip_keys:
+- - python
+  - python_impl

--- a/.ci_support/linux_ppc64le_python3.10.____cpythonpython_implcpython.yaml
+++ b/.ci_support/linux_ppc64le_python3.10.____cpythonpython_implcpython.yaml
@@ -1,7 +1,3 @@
-BUILD:
-- aarch64-conda_cos7-linux-gnu
-cdt_arch:
-- aarch64
 cdt_name:
 - cos7
 channel_sources:
@@ -10,7 +6,16 @@ channel_targets:
 - conda-forge main
 docker_image:
 - quay.io/condaforge/linux-anvil-cos7-x86_64
+pin_run_as_build:
+  python:
+    min_pin: x.x
+    max_pin: x.x
+python:
+- 3.10.* *_cpython
 python_impl:
-- pypy
+- cpython
 target_platform:
-- linux-aarch64
+- linux-ppc64le
+zip_keys:
+- - python
+  - python_impl

--- a/.ci_support/linux_ppc64le_python3.8.____73_pypypython_implpypy.yaml
+++ b/.ci_support/linux_ppc64le_python3.8.____73_pypypython_implpypy.yaml
@@ -1,0 +1,21 @@
+cdt_name:
+- cos7
+channel_sources:
+- conda-forge
+channel_targets:
+- conda-forge main
+docker_image:
+- quay.io/condaforge/linux-anvil-cos7-x86_64
+pin_run_as_build:
+  python:
+    min_pin: x.x
+    max_pin: x.x
+python:
+- 3.8.* *_73_pypy
+python_impl:
+- pypy
+target_platform:
+- linux-ppc64le
+zip_keys:
+- - python
+  - python_impl

--- a/.ci_support/linux_ppc64le_python3.8.____cpythonpython_implcpython.yaml
+++ b/.ci_support/linux_ppc64le_python3.8.____cpythonpython_implcpython.yaml
@@ -6,7 +6,16 @@ channel_targets:
 - conda-forge main
 docker_image:
 - quay.io/condaforge/linux-anvil-cos7-x86_64
+pin_run_as_build:
+  python:
+    min_pin: x.x
+    max_pin: x.x
+python:
+- 3.8.* *_cpython
 python_impl:
 - cpython
 target_platform:
 - linux-ppc64le
+zip_keys:
+- - python
+  - python_impl

--- a/.ci_support/linux_ppc64le_python3.9.____73_pypypython_implpypy.yaml
+++ b/.ci_support/linux_ppc64le_python3.9.____73_pypypython_implpypy.yaml
@@ -1,12 +1,21 @@
 cdt_name:
-- cos6
+- cos7
 channel_sources:
 - conda-forge
 channel_targets:
 - conda-forge main
 docker_image:
 - quay.io/condaforge/linux-anvil-cos7-x86_64
+pin_run_as_build:
+  python:
+    min_pin: x.x
+    max_pin: x.x
+python:
+- 3.9.* *_73_pypy
 python_impl:
 - pypy
 target_platform:
-- linux-64
+- linux-ppc64le
+zip_keys:
+- - python
+  - python_impl

--- a/.ci_support/linux_ppc64le_python3.9.____cpythonpython_implcpython.yaml
+++ b/.ci_support/linux_ppc64le_python3.9.____cpythonpython_implcpython.yaml
@@ -1,0 +1,21 @@
+cdt_name:
+- cos7
+channel_sources:
+- conda-forge
+channel_targets:
+- conda-forge main
+docker_image:
+- quay.io/condaforge/linux-anvil-cos7-x86_64
+pin_run_as_build:
+  python:
+    min_pin: x.x
+    max_pin: x.x
+python:
+- 3.9.* *_cpython
+python_impl:
+- cpython
+target_platform:
+- linux-ppc64le
+zip_keys:
+- - python
+  - python_impl

--- a/.ci_support/osx_64_python3.10.____cpythonpython_implcpython.yaml
+++ b/.ci_support/osx_64_python3.10.____cpythonpython_implcpython.yaml
@@ -1,0 +1,21 @@
+MACOSX_DEPLOYMENT_TARGET:
+- '10.9'
+channel_sources:
+- conda-forge
+channel_targets:
+- conda-forge main
+macos_machine:
+- x86_64-apple-darwin13.4.0
+pin_run_as_build:
+  python:
+    min_pin: x.x
+    max_pin: x.x
+python:
+- 3.10.* *_cpython
+python_impl:
+- cpython
+target_platform:
+- osx-64
+zip_keys:
+- - python
+  - python_impl

--- a/.ci_support/osx_64_python3.8.____73_pypypython_implpypy.yaml
+++ b/.ci_support/osx_64_python3.8.____73_pypypython_implpypy.yaml
@@ -1,0 +1,21 @@
+MACOSX_DEPLOYMENT_TARGET:
+- '10.9'
+channel_sources:
+- conda-forge
+channel_targets:
+- conda-forge main
+macos_machine:
+- x86_64-apple-darwin13.4.0
+pin_run_as_build:
+  python:
+    min_pin: x.x
+    max_pin: x.x
+python:
+- 3.8.* *_73_pypy
+python_impl:
+- pypy
+target_platform:
+- osx-64
+zip_keys:
+- - python
+  - python_impl

--- a/.ci_support/osx_64_python3.8.____cpythonpython_implcpython.yaml
+++ b/.ci_support/osx_64_python3.8.____cpythonpython_implcpython.yaml
@@ -1,0 +1,21 @@
+MACOSX_DEPLOYMENT_TARGET:
+- '10.9'
+channel_sources:
+- conda-forge
+channel_targets:
+- conda-forge main
+macos_machine:
+- x86_64-apple-darwin13.4.0
+pin_run_as_build:
+  python:
+    min_pin: x.x
+    max_pin: x.x
+python:
+- 3.8.* *_cpython
+python_impl:
+- cpython
+target_platform:
+- osx-64
+zip_keys:
+- - python
+  - python_impl

--- a/.ci_support/osx_64_python3.9.____73_pypypython_implpypy.yaml
+++ b/.ci_support/osx_64_python3.9.____73_pypypython_implpypy.yaml
@@ -6,7 +6,16 @@ channel_targets:
 - conda-forge main
 macos_machine:
 - x86_64-apple-darwin13.4.0
+pin_run_as_build:
+  python:
+    min_pin: x.x
+    max_pin: x.x
+python:
+- 3.9.* *_73_pypy
 python_impl:
-- cpython
+- pypy
 target_platform:
 - osx-64
+zip_keys:
+- - python
+  - python_impl

--- a/.ci_support/osx_64_python3.9.____cpythonpython_implcpython.yaml
+++ b/.ci_support/osx_64_python3.9.____cpythonpython_implcpython.yaml
@@ -6,7 +6,16 @@ channel_targets:
 - conda-forge main
 macos_machine:
 - x86_64-apple-darwin13.4.0
+pin_run_as_build:
+  python:
+    min_pin: x.x
+    max_pin: x.x
+python:
+- 3.9.* *_cpython
 python_impl:
-- pypy
+- cpython
 target_platform:
 - osx-64
+zip_keys:
+- - python
+  - python_impl

--- a/.ci_support/osx_arm64_python3.10.____cpython.yaml
+++ b/.ci_support/osx_arm64_python3.10.____cpython.yaml
@@ -1,0 +1,21 @@
+MACOSX_DEPLOYMENT_TARGET:
+- '11.0'
+channel_sources:
+- conda-forge
+channel_targets:
+- conda-forge main
+macos_machine:
+- arm64-apple-darwin20.0.0
+pin_run_as_build:
+  python:
+    min_pin: x.x
+    max_pin: x.x
+python:
+- 3.10.* *_cpython
+python_impl:
+- cpython
+target_platform:
+- osx-arm64
+zip_keys:
+- - python
+  - python_impl

--- a/.ci_support/osx_arm64_python3.8.____cpython.yaml
+++ b/.ci_support/osx_arm64_python3.8.____cpython.yaml
@@ -6,7 +6,16 @@ channel_targets:
 - conda-forge main
 macos_machine:
 - arm64-apple-darwin20.0.0
+pin_run_as_build:
+  python:
+    min_pin: x.x
+    max_pin: x.x
+python:
+- 3.8.* *_cpython
 python_impl:
 - cpython
 target_platform:
 - osx-arm64
+zip_keys:
+- - python
+  - python_impl

--- a/.ci_support/osx_arm64_python3.9.____cpython.yaml
+++ b/.ci_support/osx_arm64_python3.9.____cpython.yaml
@@ -1,0 +1,21 @@
+MACOSX_DEPLOYMENT_TARGET:
+- '11.0'
+channel_sources:
+- conda-forge
+channel_targets:
+- conda-forge main
+macos_machine:
+- arm64-apple-darwin20.0.0
+pin_run_as_build:
+  python:
+    min_pin: x.x
+    max_pin: x.x
+python:
+- 3.9.* *_cpython
+python_impl:
+- cpython
+target_platform:
+- osx-arm64
+zip_keys:
+- - python
+  - python_impl

--- a/.ci_support/win_64_python3.10.____cpythonpython_implcpython.yaml
+++ b/.ci_support/win_64_python3.10.____cpythonpython_implcpython.yaml
@@ -1,0 +1,17 @@
+channel_sources:
+- conda-forge
+channel_targets:
+- conda-forge main
+pin_run_as_build:
+  python:
+    min_pin: x.x
+    max_pin: x.x
+python:
+- 3.10.* *_cpython
+python_impl:
+- cpython
+target_platform:
+- win-64
+zip_keys:
+- - python
+  - python_impl

--- a/.ci_support/win_64_python3.8.____73_pypypython_implpypy.yaml
+++ b/.ci_support/win_64_python3.8.____73_pypypython_implpypy.yaml
@@ -1,0 +1,17 @@
+channel_sources:
+- conda-forge
+channel_targets:
+- conda-forge main
+pin_run_as_build:
+  python:
+    min_pin: x.x
+    max_pin: x.x
+python:
+- 3.8.* *_73_pypy
+python_impl:
+- pypy
+target_platform:
+- win-64
+zip_keys:
+- - python
+  - python_impl

--- a/.ci_support/win_64_python3.8.____cpythonpython_implcpython.yaml
+++ b/.ci_support/win_64_python3.8.____cpythonpython_implcpython.yaml
@@ -1,0 +1,17 @@
+channel_sources:
+- conda-forge
+channel_targets:
+- conda-forge main
+pin_run_as_build:
+  python:
+    min_pin: x.x
+    max_pin: x.x
+python:
+- 3.8.* *_cpython
+python_impl:
+- cpython
+target_platform:
+- win-64
+zip_keys:
+- - python
+  - python_impl

--- a/.ci_support/win_64_python3.9.____73_pypypython_implpypy.yaml
+++ b/.ci_support/win_64_python3.9.____73_pypypython_implpypy.yaml
@@ -1,0 +1,17 @@
+channel_sources:
+- conda-forge
+channel_targets:
+- conda-forge main
+pin_run_as_build:
+  python:
+    min_pin: x.x
+    max_pin: x.x
+python:
+- 3.9.* *_73_pypy
+python_impl:
+- pypy
+target_platform:
+- win-64
+zip_keys:
+- - python
+  - python_impl

--- a/.ci_support/win_64_python3.9.____cpythonpython_implcpython.yaml
+++ b/.ci_support/win_64_python3.9.____cpythonpython_implcpython.yaml
@@ -1,0 +1,17 @@
+channel_sources:
+- conda-forge
+channel_targets:
+- conda-forge main
+pin_run_as_build:
+  python:
+    min_pin: x.x
+    max_pin: x.x
+python:
+- 3.9.* *_cpython
+python_impl:
+- cpython
+target_platform:
+- win-64
+zip_keys:
+- - python
+  - python_impl

--- a/.ci_support/win_64_python_implcpython.yaml
+++ b/.ci_support/win_64_python_implcpython.yaml
@@ -1,8 +1,0 @@
-channel_sources:
-- conda-forge
-channel_targets:
-- conda-forge main
-python_impl:
-- cpython
-target_platform:
-- win-64

--- a/.ci_support/win_64_python_implpypy.yaml
+++ b/.ci_support/win_64_python_implpypy.yaml
@@ -1,8 +1,0 @@
-channel_sources:
-- conda-forge
-channel_targets:
-- conda-forge main
-python_impl:
-- pypy
-target_platform:
-- win-64

--- a/README.md
+++ b/README.md
@@ -36,80 +36,199 @@ Current build status
         <table>
           <thead><tr><th>Variant</th><th>Status</th></tr></thead>
           <tbody><tr>
-              <td>linux_64_python_implcpython</td>
+              <td>linux_64_python3.10.____cpythonpython_implcpython</td>
               <td>
                 <a href="https://dev.azure.com/conda-forge/feedstock-builds/_build/latest?definitionId=1986&branchName=main">
-                  <img src="https://dev.azure.com/conda-forge/feedstock-builds/_apis/build/status/sympy-feedstock?branchName=main&jobName=linux&configuration=linux_64_python_implcpython" alt="variant">
+                  <img src="https://dev.azure.com/conda-forge/feedstock-builds/_apis/build/status/sympy-feedstock?branchName=main&jobName=linux&configuration=linux_64_python3.10.____cpythonpython_implcpython" alt="variant">
                 </a>
               </td>
             </tr><tr>
-              <td>linux_64_python_implpypy</td>
+              <td>linux_64_python3.8.____73_pypypython_implpypy</td>
               <td>
                 <a href="https://dev.azure.com/conda-forge/feedstock-builds/_build/latest?definitionId=1986&branchName=main">
-                  <img src="https://dev.azure.com/conda-forge/feedstock-builds/_apis/build/status/sympy-feedstock?branchName=main&jobName=linux&configuration=linux_64_python_implpypy" alt="variant">
+                  <img src="https://dev.azure.com/conda-forge/feedstock-builds/_apis/build/status/sympy-feedstock?branchName=main&jobName=linux&configuration=linux_64_python3.8.____73_pypypython_implpypy" alt="variant">
                 </a>
               </td>
             </tr><tr>
-              <td>linux_aarch64_python_implcpython</td>
+              <td>linux_64_python3.8.____cpythonpython_implcpython</td>
               <td>
                 <a href="https://dev.azure.com/conda-forge/feedstock-builds/_build/latest?definitionId=1986&branchName=main">
-                  <img src="https://dev.azure.com/conda-forge/feedstock-builds/_apis/build/status/sympy-feedstock?branchName=main&jobName=linux&configuration=linux_aarch64_python_implcpython" alt="variant">
+                  <img src="https://dev.azure.com/conda-forge/feedstock-builds/_apis/build/status/sympy-feedstock?branchName=main&jobName=linux&configuration=linux_64_python3.8.____cpythonpython_implcpython" alt="variant">
                 </a>
               </td>
             </tr><tr>
-              <td>linux_aarch64_python_implpypy</td>
+              <td>linux_64_python3.9.____73_pypypython_implpypy</td>
               <td>
                 <a href="https://dev.azure.com/conda-forge/feedstock-builds/_build/latest?definitionId=1986&branchName=main">
-                  <img src="https://dev.azure.com/conda-forge/feedstock-builds/_apis/build/status/sympy-feedstock?branchName=main&jobName=linux&configuration=linux_aarch64_python_implpypy" alt="variant">
+                  <img src="https://dev.azure.com/conda-forge/feedstock-builds/_apis/build/status/sympy-feedstock?branchName=main&jobName=linux&configuration=linux_64_python3.9.____73_pypypython_implpypy" alt="variant">
                 </a>
               </td>
             </tr><tr>
-              <td>linux_ppc64le_python_implcpython</td>
+              <td>linux_64_python3.9.____cpythonpython_implcpython</td>
               <td>
                 <a href="https://dev.azure.com/conda-forge/feedstock-builds/_build/latest?definitionId=1986&branchName=main">
-                  <img src="https://dev.azure.com/conda-forge/feedstock-builds/_apis/build/status/sympy-feedstock?branchName=main&jobName=linux&configuration=linux_ppc64le_python_implcpython" alt="variant">
+                  <img src="https://dev.azure.com/conda-forge/feedstock-builds/_apis/build/status/sympy-feedstock?branchName=main&jobName=linux&configuration=linux_64_python3.9.____cpythonpython_implcpython" alt="variant">
                 </a>
               </td>
             </tr><tr>
-              <td>linux_ppc64le_python_implpypy</td>
+              <td>linux_aarch64_python3.10.____cpythonpython_implcpython</td>
               <td>
                 <a href="https://dev.azure.com/conda-forge/feedstock-builds/_build/latest?definitionId=1986&branchName=main">
-                  <img src="https://dev.azure.com/conda-forge/feedstock-builds/_apis/build/status/sympy-feedstock?branchName=main&jobName=linux&configuration=linux_ppc64le_python_implpypy" alt="variant">
+                  <img src="https://dev.azure.com/conda-forge/feedstock-builds/_apis/build/status/sympy-feedstock?branchName=main&jobName=linux&configuration=linux_aarch64_python3.10.____cpythonpython_implcpython" alt="variant">
                 </a>
               </td>
             </tr><tr>
-              <td>osx_64_python_implcpython</td>
+              <td>linux_aarch64_python3.8.____73_pypypython_implpypy</td>
               <td>
                 <a href="https://dev.azure.com/conda-forge/feedstock-builds/_build/latest?definitionId=1986&branchName=main">
-                  <img src="https://dev.azure.com/conda-forge/feedstock-builds/_apis/build/status/sympy-feedstock?branchName=main&jobName=osx&configuration=osx_64_python_implcpython" alt="variant">
+                  <img src="https://dev.azure.com/conda-forge/feedstock-builds/_apis/build/status/sympy-feedstock?branchName=main&jobName=linux&configuration=linux_aarch64_python3.8.____73_pypypython_implpypy" alt="variant">
                 </a>
               </td>
             </tr><tr>
-              <td>osx_64_python_implpypy</td>
+              <td>linux_aarch64_python3.8.____cpythonpython_implcpython</td>
               <td>
                 <a href="https://dev.azure.com/conda-forge/feedstock-builds/_build/latest?definitionId=1986&branchName=main">
-                  <img src="https://dev.azure.com/conda-forge/feedstock-builds/_apis/build/status/sympy-feedstock?branchName=main&jobName=osx&configuration=osx_64_python_implpypy" alt="variant">
+                  <img src="https://dev.azure.com/conda-forge/feedstock-builds/_apis/build/status/sympy-feedstock?branchName=main&jobName=linux&configuration=linux_aarch64_python3.8.____cpythonpython_implcpython" alt="variant">
                 </a>
               </td>
             </tr><tr>
-              <td>osx_arm64</td>
+              <td>linux_aarch64_python3.9.____73_pypypython_implpypy</td>
               <td>
                 <a href="https://dev.azure.com/conda-forge/feedstock-builds/_build/latest?definitionId=1986&branchName=main">
-                  <img src="https://dev.azure.com/conda-forge/feedstock-builds/_apis/build/status/sympy-feedstock?branchName=main&jobName=osx&configuration=osx_arm64_" alt="variant">
+                  <img src="https://dev.azure.com/conda-forge/feedstock-builds/_apis/build/status/sympy-feedstock?branchName=main&jobName=linux&configuration=linux_aarch64_python3.9.____73_pypypython_implpypy" alt="variant">
                 </a>
               </td>
             </tr><tr>
-              <td>win_64_python_implcpython</td>
+              <td>linux_aarch64_python3.9.____cpythonpython_implcpython</td>
               <td>
                 <a href="https://dev.azure.com/conda-forge/feedstock-builds/_build/latest?definitionId=1986&branchName=main">
-                  <img src="https://dev.azure.com/conda-forge/feedstock-builds/_apis/build/status/sympy-feedstock?branchName=main&jobName=win&configuration=win_64_python_implcpython" alt="variant">
+                  <img src="https://dev.azure.com/conda-forge/feedstock-builds/_apis/build/status/sympy-feedstock?branchName=main&jobName=linux&configuration=linux_aarch64_python3.9.____cpythonpython_implcpython" alt="variant">
                 </a>
               </td>
             </tr><tr>
-              <td>win_64_python_implpypy</td>
+              <td>linux_ppc64le_python3.10.____cpythonpython_implcpython</td>
               <td>
                 <a href="https://dev.azure.com/conda-forge/feedstock-builds/_build/latest?definitionId=1986&branchName=main">
-                  <img src="https://dev.azure.com/conda-forge/feedstock-builds/_apis/build/status/sympy-feedstock?branchName=main&jobName=win&configuration=win_64_python_implpypy" alt="variant">
+                  <img src="https://dev.azure.com/conda-forge/feedstock-builds/_apis/build/status/sympy-feedstock?branchName=main&jobName=linux&configuration=linux_ppc64le_python3.10.____cpythonpython_implcpython" alt="variant">
+                </a>
+              </td>
+            </tr><tr>
+              <td>linux_ppc64le_python3.8.____73_pypypython_implpypy</td>
+              <td>
+                <a href="https://dev.azure.com/conda-forge/feedstock-builds/_build/latest?definitionId=1986&branchName=main">
+                  <img src="https://dev.azure.com/conda-forge/feedstock-builds/_apis/build/status/sympy-feedstock?branchName=main&jobName=linux&configuration=linux_ppc64le_python3.8.____73_pypypython_implpypy" alt="variant">
+                </a>
+              </td>
+            </tr><tr>
+              <td>linux_ppc64le_python3.8.____cpythonpython_implcpython</td>
+              <td>
+                <a href="https://dev.azure.com/conda-forge/feedstock-builds/_build/latest?definitionId=1986&branchName=main">
+                  <img src="https://dev.azure.com/conda-forge/feedstock-builds/_apis/build/status/sympy-feedstock?branchName=main&jobName=linux&configuration=linux_ppc64le_python3.8.____cpythonpython_implcpython" alt="variant">
+                </a>
+              </td>
+            </tr><tr>
+              <td>linux_ppc64le_python3.9.____73_pypypython_implpypy</td>
+              <td>
+                <a href="https://dev.azure.com/conda-forge/feedstock-builds/_build/latest?definitionId=1986&branchName=main">
+                  <img src="https://dev.azure.com/conda-forge/feedstock-builds/_apis/build/status/sympy-feedstock?branchName=main&jobName=linux&configuration=linux_ppc64le_python3.9.____73_pypypython_implpypy" alt="variant">
+                </a>
+              </td>
+            </tr><tr>
+              <td>linux_ppc64le_python3.9.____cpythonpython_implcpython</td>
+              <td>
+                <a href="https://dev.azure.com/conda-forge/feedstock-builds/_build/latest?definitionId=1986&branchName=main">
+                  <img src="https://dev.azure.com/conda-forge/feedstock-builds/_apis/build/status/sympy-feedstock?branchName=main&jobName=linux&configuration=linux_ppc64le_python3.9.____cpythonpython_implcpython" alt="variant">
+                </a>
+              </td>
+            </tr><tr>
+              <td>osx_64_python3.10.____cpythonpython_implcpython</td>
+              <td>
+                <a href="https://dev.azure.com/conda-forge/feedstock-builds/_build/latest?definitionId=1986&branchName=main">
+                  <img src="https://dev.azure.com/conda-forge/feedstock-builds/_apis/build/status/sympy-feedstock?branchName=main&jobName=osx&configuration=osx_64_python3.10.____cpythonpython_implcpython" alt="variant">
+                </a>
+              </td>
+            </tr><tr>
+              <td>osx_64_python3.8.____73_pypypython_implpypy</td>
+              <td>
+                <a href="https://dev.azure.com/conda-forge/feedstock-builds/_build/latest?definitionId=1986&branchName=main">
+                  <img src="https://dev.azure.com/conda-forge/feedstock-builds/_apis/build/status/sympy-feedstock?branchName=main&jobName=osx&configuration=osx_64_python3.8.____73_pypypython_implpypy" alt="variant">
+                </a>
+              </td>
+            </tr><tr>
+              <td>osx_64_python3.8.____cpythonpython_implcpython</td>
+              <td>
+                <a href="https://dev.azure.com/conda-forge/feedstock-builds/_build/latest?definitionId=1986&branchName=main">
+                  <img src="https://dev.azure.com/conda-forge/feedstock-builds/_apis/build/status/sympy-feedstock?branchName=main&jobName=osx&configuration=osx_64_python3.8.____cpythonpython_implcpython" alt="variant">
+                </a>
+              </td>
+            </tr><tr>
+              <td>osx_64_python3.9.____73_pypypython_implpypy</td>
+              <td>
+                <a href="https://dev.azure.com/conda-forge/feedstock-builds/_build/latest?definitionId=1986&branchName=main">
+                  <img src="https://dev.azure.com/conda-forge/feedstock-builds/_apis/build/status/sympy-feedstock?branchName=main&jobName=osx&configuration=osx_64_python3.9.____73_pypypython_implpypy" alt="variant">
+                </a>
+              </td>
+            </tr><tr>
+              <td>osx_64_python3.9.____cpythonpython_implcpython</td>
+              <td>
+                <a href="https://dev.azure.com/conda-forge/feedstock-builds/_build/latest?definitionId=1986&branchName=main">
+                  <img src="https://dev.azure.com/conda-forge/feedstock-builds/_apis/build/status/sympy-feedstock?branchName=main&jobName=osx&configuration=osx_64_python3.9.____cpythonpython_implcpython" alt="variant">
+                </a>
+              </td>
+            </tr><tr>
+              <td>osx_arm64_python3.10.____cpython</td>
+              <td>
+                <a href="https://dev.azure.com/conda-forge/feedstock-builds/_build/latest?definitionId=1986&branchName=main">
+                  <img src="https://dev.azure.com/conda-forge/feedstock-builds/_apis/build/status/sympy-feedstock?branchName=main&jobName=osx&configuration=osx_arm64_python3.10.____cpython" alt="variant">
+                </a>
+              </td>
+            </tr><tr>
+              <td>osx_arm64_python3.8.____cpython</td>
+              <td>
+                <a href="https://dev.azure.com/conda-forge/feedstock-builds/_build/latest?definitionId=1986&branchName=main">
+                  <img src="https://dev.azure.com/conda-forge/feedstock-builds/_apis/build/status/sympy-feedstock?branchName=main&jobName=osx&configuration=osx_arm64_python3.8.____cpython" alt="variant">
+                </a>
+              </td>
+            </tr><tr>
+              <td>osx_arm64_python3.9.____cpython</td>
+              <td>
+                <a href="https://dev.azure.com/conda-forge/feedstock-builds/_build/latest?definitionId=1986&branchName=main">
+                  <img src="https://dev.azure.com/conda-forge/feedstock-builds/_apis/build/status/sympy-feedstock?branchName=main&jobName=osx&configuration=osx_arm64_python3.9.____cpython" alt="variant">
+                </a>
+              </td>
+            </tr><tr>
+              <td>win_64_python3.10.____cpythonpython_implcpython</td>
+              <td>
+                <a href="https://dev.azure.com/conda-forge/feedstock-builds/_build/latest?definitionId=1986&branchName=main">
+                  <img src="https://dev.azure.com/conda-forge/feedstock-builds/_apis/build/status/sympy-feedstock?branchName=main&jobName=win&configuration=win_64_python3.10.____cpythonpython_implcpython" alt="variant">
+                </a>
+              </td>
+            </tr><tr>
+              <td>win_64_python3.8.____73_pypypython_implpypy</td>
+              <td>
+                <a href="https://dev.azure.com/conda-forge/feedstock-builds/_build/latest?definitionId=1986&branchName=main">
+                  <img src="https://dev.azure.com/conda-forge/feedstock-builds/_apis/build/status/sympy-feedstock?branchName=main&jobName=win&configuration=win_64_python3.8.____73_pypypython_implpypy" alt="variant">
+                </a>
+              </td>
+            </tr><tr>
+              <td>win_64_python3.8.____cpythonpython_implcpython</td>
+              <td>
+                <a href="https://dev.azure.com/conda-forge/feedstock-builds/_build/latest?definitionId=1986&branchName=main">
+                  <img src="https://dev.azure.com/conda-forge/feedstock-builds/_apis/build/status/sympy-feedstock?branchName=main&jobName=win&configuration=win_64_python3.8.____cpythonpython_implcpython" alt="variant">
+                </a>
+              </td>
+            </tr><tr>
+              <td>win_64_python3.9.____73_pypypython_implpypy</td>
+              <td>
+                <a href="https://dev.azure.com/conda-forge/feedstock-builds/_build/latest?definitionId=1986&branchName=main">
+                  <img src="https://dev.azure.com/conda-forge/feedstock-builds/_apis/build/status/sympy-feedstock?branchName=main&jobName=win&configuration=win_64_python3.9.____73_pypypython_implpypy" alt="variant">
+                </a>
+              </td>
+            </tr><tr>
+              <td>win_64_python3.9.____cpythonpython_implcpython</td>
+              <td>
+                <a href="https://dev.azure.com/conda-forge/feedstock-builds/_build/latest?definitionId=1986&branchName=main">
+                  <img src="https://dev.azure.com/conda-forge/feedstock-builds/_apis/build/status/sympy-feedstock?branchName=main&jobName=win&configuration=win_64_python3.9.____cpythonpython_implcpython" alt="variant">
                 </a>
               </td>
             </tr>

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -9,7 +9,7 @@ source:
   sha256: e32380dce63cb7c0108ed525570092fd45168bdae2faa17e528221ef72e88658
 
 build:
-  number: 0
+  number: 1
   script: {{ PYTHON }} -m pip install . --no-deps --ignore-installed --no-cache-dir -vvv
   entry_points:
     - isympy = isympy:main
@@ -28,7 +28,7 @@ requirements:
     - python
     - gmpy2 >=2.0.8   # [python_impl == "cpython" and not win]
   run_constrained:
-    - antlr-python-runtime >=4.7,<4.8
+    - antlr-python-runtime >=4.10,<4.11
 
 test:
   commands:


### PR DESCRIPTION
This has been updated in https://github.com/sympy/sympy/commit/ab2602af0f52c916077ea5b505e3f218d3cac33b since 1.11

<!--
Thank you for your pull request.
Below are a few things we ask you kindly to self-check before getting a review. Remove checks that are not relevant.
-->
Checklist
* [x] Used a [personal fork of the feedstock to propose changes](https://conda-forge.org/docs/maintainer/updating_pkgs.html#forking-and-pull-requests)
* [x] Bumped the build number (if the version is unchanged)
* [x] Reset the build number to `0` (if the version changed)
* [x] [Re-rendered]( https://conda-forge.org/docs/maintainer/updating_pkgs.html#rerendering-feedstocks ) with the latest `conda-smithy` (Use the phrase <code>@<space/>conda-forge-admin, please rerender</code> in a comment in this PR for automated rerendering)
* [x] Ensured the license file is being packaged.

<!--
Please note any issues this fixes using [closing keywords]( https://help.github.com/articles/closing-issues-using-keywords/ ):
-->

<!--
Please add any other relevant info below:
-->
